### PR TITLE
refactor controllers to use async fs operations

### DIFF
--- a/controllers/contentController.js
+++ b/controllers/contentController.js
@@ -1,31 +1,60 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const FOLDER_PATH = path.join(__dirname, '../uploads');
 
 exports.listFolders = async (req, res) => {
-  const folders = fs.readdirSync(FOLDER_PATH);
-  res.json(folders);
+  try {
+    const folders = await fs.readdir(FOLDER_PATH);
+    res.json(folders);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to list folders' });
+  }
 };
 
 exports.createFolder = async (req, res) => {
   const { name } = req.body;
   const folderPath = path.join(FOLDER_PATH, name);
-  if (!fs.existsSync(folderPath)) fs.mkdirSync(folderPath);
-  res.json({ success: true });
+  try {
+    await fs.mkdir(folderPath, { recursive: true });
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to create folder' });
+  }
 };
 
 exports.deleteFolder = async (req, res) => {
   const folderPath = path.join(FOLDER_PATH, req.params.id);
-  if (fs.existsSync(folderPath)) fs.rmdirSync(folderPath, { recursive: true });
-  res.json({ success: true });
+  try {
+    await fs.rm(folderPath, { recursive: true, force: true });
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete folder' });
+  }
 };
 
 exports.uploadFile = async (req, res) => {
-  res.json({ message: 'Logika uploadu do wdrożenia (np. multer, Cloudflare R2)' });
+  try {
+    res.json({ message: 'Logika uploadu do wdrożenia (np. multer, Cloudflare R2)' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to upload file' });
+  }
 };
 
 exports.deleteFile = async (req, res) => {
   const filePath = path.join(FOLDER_PATH, req.params.filename);
-  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
-  res.json({ success: true });
+  try {
+    await fs.unlink(filePath);
+    res.json({ success: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.json({ success: true });
+    } else {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to delete file' });
+    }
+  }
 };

--- a/controllers/ftpController.js
+++ b/controllers/ftpController.js
@@ -1,20 +1,38 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const FTP_PATH = path.join(__dirname, '../ftp-folder');
 const ASSIGNED_LOG = path.join(__dirname, '../ftp-folder/.assigned.json');
 
-if (!fs.existsSync(ASSIGNED_LOG)) fs.writeFileSync(ASSIGNED_LOG, JSON.stringify([]));
+(async () => {
+  try {
+    await fs.access(ASSIGNED_LOG);
+  } catch {
+    await fs.writeFile(ASSIGNED_LOG, JSON.stringify([]));
+  }
+})();
 
 exports.getNewFiles = async (req, res) => {
-  const assigned = JSON.parse(fs.readFileSync(ASSIGNED_LOG));
-  const files = fs.readdirSync(FTP_PATH).filter(f => f !== '.assigned.json' && !assigned.includes(f));
-  res.json(files);
+  try {
+    const assignedData = await fs.readFile(ASSIGNED_LOG, 'utf8');
+    const assigned = JSON.parse(assignedData);
+    const files = (await fs.readdir(FTP_PATH)).filter(f => f !== '.assigned.json' && !assigned.includes(f));
+    res.json(files);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to retrieve new files' });
+  }
 };
 
 exports.assignFileToFolder = async (req, res) => {
   const { fileName, folderId } = req.body;
-  const assigned = JSON.parse(fs.readFileSync(ASSIGNED_LOG));
-  if (!assigned.includes(fileName)) assigned.push(fileName);
-  fs.writeFileSync(ASSIGNED_LOG, JSON.stringify(assigned));
-  res.json({ success: true, message: `Plik ${fileName} przypisany do folderu ${folderId}` });
+  try {
+    const assignedData = await fs.readFile(ASSIGNED_LOG, 'utf8');
+    const assigned = JSON.parse(assignedData);
+    if (!assigned.includes(fileName)) assigned.push(fileName);
+    await fs.writeFile(ASSIGNED_LOG, JSON.stringify(assigned));
+    res.json({ success: true, message: `Plik ${fileName} przypisany do folderu ${folderId}` });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to assign file to folder' });
+  }
 };


### PR DESCRIPTION
## Summary
- replace synchronous filesystem access in contentController with `fs.promises` and error handling
- refactor ftpController to use async fs methods and centralized error responses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689496f720788328976912a2e7c48cb8