### PR TITLE
feat: add admin middleware

### DIFF
--- a/controllers/notificationController.js
+++ b/controllers/notificationController.js
@@ -10,6 +10,7 @@ exports.markAsRead = async (req, res) => {
   res.json({ success: true });
 };
 
+// Only admins can create notifications; enforced via adminMiddleware on the route
 exports.createNotification = async (req, res) => {
   const { userId, type, message } = req.body;
   await Notification.create({ userId, type, message });

--- a/middleware/adminMiddleware.js
+++ b/middleware/adminMiddleware.js
@@ -1,0 +1,10 @@
+const adminMiddleware = (req, res, next) => {
+  const user = req.user;
+  // Check if user has admin role or flag
+  if (!user || !(user.role === 'admin' || user.isAdmin)) {
+    return res.status(403).json({ msg: 'Brak uprawnień administratora' });
+  }
+  next();
+};
+
+module.exports = adminMiddleware;

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -2,9 +2,11 @@ const express = require('express');
 const router = express.Router();
 const { getNotifications, markAsRead, createNotification } = require('../controllers/notificationController');
 const auth = require('../middleware/authMiddleware');
+const admin = require('../middleware/adminMiddleware');
 
 router.get('/', auth, getNotifications);
 router.post('/read/:id', auth, markAsRead);
-router.post('/create', auth, createNotification); // Admin only in real use
+// Creating notifications requires admin privileges
+router.post('/create', auth, admin, createNotification);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add admin middleware to enforce role or flag for admin-only routes
- guard notification creation route with authentication and admin middleware
- document that only admins may create notifications

## Testing
- `npm test` *(fails: ENOENT, could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689496fac524832880930cd9e547345a