### PR TITLE
Validate Bearer token format in auth middleware

### DIFF
--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,7 +1,15 @@
 const jwt = require('jsonwebtoken');
 module.exports = (req, res, next) => {
-  const token = req.header('Authorization');
-  if (!token) return res.status(401).json({ msg: 'Brak tokenu, brak dostępu' });
+  const authHeader = req.header('Authorization');
+  if (!authHeader) {
+    return res.status(401).json({ msg: 'Brak tokenu, brak dostępu' });
+  }
+
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ msg: 'Nieprawidłowy format tokenu' });
+  }
+
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded.user;


### PR DESCRIPTION
## Summary
- ensure `Authorization` header uses `Bearer` scheme and return 401 for missing or malformed tokens
- verify extracted JWT and handle verification errors gracefully

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689496f872dc8328aba1f360116ccd64