### PR TITLE
Hash user passwords with bcrypt

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,3 +1,32 @@
-exports.register = (req, res) => {/* handle registration */};
-exports.login = (req, res) => {/* handle login */};
-exports.discordOAuth = (req, res) => {/* handle Discord OAuth */};
+const User = require('../models/User');
+
+exports.register = async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const user = new User({ email, password });
+    await user.save();
+    res.status(201).json({ message: 'User registered' });
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+};
+
+exports.login = async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ msg: 'Invalid credentials' });
+
+    const isMatch = await user.comparePassword(password);
+    if (!isMatch) return res.status(400).json({ msg: 'Invalid credentials' });
+
+    res.json({ message: 'Logged in' });
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+};
+
+exports.discordOAuth = (req, res) => {
+  /* handle Discord OAuth */
+};
+

--- a/models/User.js
+++ b/models/User.js
@@ -1,10 +1,29 @@
 const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
+
 const UserSchema = new mongoose.Schema({
-  email: String,
-  password: String,
+  email: { type: String, required: true },
+  password: { type: String, required: true },
   discordId: String,
   banned: { type: Boolean, default: false },
   credits: { type: Number, default: 0 },
   access: [{ folderId: String, expiresAt: Date }]
 });
+
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  try {
+    const salt = await bcrypt.genSalt(10);
+    this.password = await bcrypt.hash(this.password, salt);
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+UserSchema.methods.comparePassword = function (candidatePassword) {
+  return bcrypt.compare(candidatePassword, this.password);
+};
+
 module.exports = mongoose.model('User', UserSchema);
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dyskiof-net-",
+  "version": "1.0.0",
+  "description": "Ten backend to gotowe rozwiązanie do prowadzenia platformy z płatnym dostępem do treści (obrazy, wideo, pliki). System obsługuje użytkowników, kredyty, dostęp do folderów, czat, powiadomienia, CMS i więcej.",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcrypt": "^5.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add bcrypt dependency
- hash user passwords and expose compare method on User model
- implement registration and login using hashed passwords

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install bcrypt` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689496f26f6c8328a0f6a2eaf6e761a0