### PR TITLE
feat: add mongoose database connection

### DIFF
--- a/utils/db.js
+++ b/utils/db.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const connectDB = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI);
+    console.log('MongoDB connected');
+  } catch (err) {
+    console.error('MongoDB connection error:', err.message);
+    process.exit(1);
+  }
+};
+
+module.exports = connectDB;


### PR DESCRIPTION
## Summary
- add database connection helper using mongoose
- keep server initialization invoking the connector

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689496eee61c83289891c57f74d92c7f