### PR TITLE
Add JWT utilities and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Ten backend to gotowe rozwiązanie do prowadzenia platformy z płatnym dostępem do treści (obrazy, wideo, pliki). System obsługuje użytkowników, kredyty, dostęp do folderów, czat, powiadomienia, CMS i więcej.",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"No tests\"",
+    "test": "node --test",
     "start": "node server.js",
     "dev": "node server.js"
   },

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { signToken, verifyToken } = require('../utils/jwt');
+
+test('sign and verify token', () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const token = signToken({ id: 'user123' });
+  assert.equal(typeof token, 'string');
+  const decoded = verifyToken(token);
+  assert.equal(decoded.id, 'user123');
+});

--- a/utils/jwt.js
+++ b/utils/jwt.js
@@ -1,2 +1,12 @@
-exports.signToken = (user) => {/* sign JWT */};
-exports.verifyToken = (token) => {/* verify JWT */};
+const jwt = require('jsonwebtoken');
+
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+exports.signToken = (user) => {
+  return jwt.sign({ id: user.id }, SECRET, { expiresIn: '1h' });
+};
+
+exports.verifyToken = (token) => {
+  return jwt.verify(token, SECRET);
+};
+


### PR DESCRIPTION
## Summary
- implement JWT sign and verify helpers
- add Node test for JWT utilities
- update test script and ignore node_modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68949f7043fc8328af70a06668efa668